### PR TITLE
Keep defines in original order

### DIFF
--- a/m2ctx.py
+++ b/m2ctx.py
@@ -27,20 +27,18 @@ CPP_FLAGS = [
 
 def import_c_file(in_file) -> str:
     in_file = os.path.relpath(in_file, root_dir)
-    cpp_command = ["gcc", "-E", "-P", "-dM", *CPP_FLAGS, in_file]
-    cpp_command2 = ["gcc", "-E", "-P", *CPP_FLAGS, in_file]
+
+    cpp_command = ["gcc", "-E", "-P", "-dD", *CPP_FLAGS, in_file]
 
     with tempfile.NamedTemporaryFile(suffix=".c") as tmp:
         stock_macros = subprocess.check_output(["gcc", "-E", "-P", "-dM", tmp.name], cwd=root_dir, encoding="utf-8")
 
-    out_text = ""
     try:
-        out_text += subprocess.check_output(cpp_command, cwd=root_dir, encoding="utf-8")
-        out_text += subprocess.check_output(cpp_command2, cwd=root_dir, encoding="utf-8")
+        out_text = subprocess.check_output(cpp_command, cwd=root_dir, encoding="utf-8")
     except subprocess.CalledProcessError:
         print(
             "Failed to preprocess input file, when running command:\n"
-            + ' '.join(cpp_command),
+            + " ".join(cpp_command),
             file=sys.stderr,
             )
         sys.exit(1)
@@ -49,9 +47,25 @@ def import_c_file(in_file) -> str:
         print("Output is empty - aborting")
         sys.exit(1)
 
+    defines = {}
+    source_lines = []
+    for line in out_text.splitlines(keepends=True):
+        if line.startswith("#define"):
+            sym = line.split()[1].split("(")[0]
+            defines[sym] = line
+        elif line.startswith("#undef"):
+            sym = line.split()[1]
+            if sym in defines:
+                del defines[sym]
+        else:
+            source_lines.append(line)
+
     for line in stock_macros.strip().splitlines():
-        out_text = out_text.replace(line + "\n", "")
-    return out_text
+        sym = line.split()[1].split("(")[0]
+        if sym in defines:
+            del defines[sym]
+
+    return "".join(defines.values()) + "".join(source_lines)
 
 def main():
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
-dM shuffles defines semi-randomly, probably due to a hashmap traversal within gcc. -dD doesn't. This allows using the generated context for permuter imports and makes it easier to read.